### PR TITLE
Add deterministic seeding for Swift agent CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ The executable supports several collaborative options to explore the agent's beh
 | `--summary` | Print a detailed emotional summary and recent experiences after processing inputs. |
 | `--history <n>` | Emit a summary of the last `n` experiences (defaults to 5 when `n` is omitted). Works alone or alongside `--summary`. |
 | `--log <path>` | Export the recorded experiences as a JSON document so you can visualise or analyse them later. |
+| `--seed <n>` | Run the simulation with a deterministic random seed (unsigned integer) so outcomes can be reproduced exactly. |
 
-Inputs supplied after the options are processed sequentially. Each input maps its leading character to an emotional adjustment (e.g., `A` energises joy and curiosity, `!` spikes anger and fear, `@` fosters trust). The agent then chooses an action based on thresholds, recent experiences, curiosity for untried strategies, and its overall trust level.
+Inputs supplied after the options are processed sequentially. Each input maps its leading character to an emotional adjustment (e.g., `A` energises joy and curiosity, `!` spikes anger and fear, `@` fosters trust). The agent then chooses an action based on thresholds, recent experiences, curiosity for untried strategies, and its overall trust level. When a seed is provided, every stochastic choice (such as outcomes or exploratory actions) is replayable for debugging or demonstrations.
 
 ### Programmatic usage
 


### PR DESCRIPTION
## Summary
- add a seedable random number generator to the Swift emotional model so stochastic choices can be reproduced
- expose a new `--seed` command-line option and print the chosen seed for clarity
- document the deterministic mode in the README

## Testing
- swift build *(fails: package requires Swift tools version 6.2.0 but 6.1.0 is installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68faabdbbca88327a87c0e5dd23f9b01