### PR TITLE
Add summary-file export option for Swift CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The executable supports several collaborative options to explore the agent's beh
 | `--seed <n>` | Run the simulation with a deterministic random seed (unsigned integer) so outcomes can be reproduced exactly. |
 | `--lexicon <path>` | Load a custom sentiment lexicon from a JSON file to map specific inputs to emotional adjustments. |
 | `--visualize <path>` | Export an HTML visualization of the experiences to the specified path. |
+| `--summary-file <path>` | Save the same summary shown by `--summary` into a plain-text report file for sharing or automation. |
 
 Inputs supplied after the options are processed sequentially. Each input maps its leading character to an emotional adjustment (e.g., `A` energises joy and curiosity, `!` spikes anger and fear, `@` fosters trust). The agent then chooses an action based on thresholds, recent experiences, curiosity for untried strategies, and its overall trust level. When a seed is provided, every stochastic choice (such as outcomes or exploratory actions) is replayable for debugging or demonstrations.
 

--- a/swift-ai-computer/Sources/swift-ai-computer/AISupercomputer.swift
+++ b/swift-ai-computer/Sources/swift-ai-computer/AISupercomputer.swift
@@ -196,6 +196,12 @@ final class AISupercomputer {
         try data.write(to: url, options: .atomic)
     }
 
+    // Self-awareness: Sharing a compact report artifact with other tools.
+    func exportSummary(to url: URL, limit: Int = 5) throws {
+        let summary = summaryReport(limit: max(limit, 1))
+        try summary.write(to: url, atomically: true, encoding: .utf8)
+    }
+
     // Self-awareness: Generating visual insights for deeper analysis.
     func exportVisualization(to url: URL) throws {
         let title = "AI Supercomputer - Experience Visualization"

--- a/swift-ai-computer/Sources/swift-ai-computer/main.swift
+++ b/swift-ai-computer/Sources/swift-ai-computer/main.swift
@@ -9,6 +9,7 @@ struct CLIOptions {
     var seed: UInt64?
     var lexiconPath: String?
     var visualizationPath: String?
+    var summaryPath: String?
 }
 
 private func parseCLIOptions(arguments: ArraySlice<String>) -> (CLIOptions, [String]) {
@@ -62,6 +63,14 @@ private func parseCLIOptions(arguments: ArraySlice<String>) -> (CLIOptions, [Str
                 index = nextIndex
             } else {
                 print("Warning: --visualize requires a file path. Ignoring option.")
+            }
+        case "--summary-file":
+            let nextIndex = arguments.index(after: index)
+            if nextIndex < arguments.endIndex {
+                options.summaryPath = arguments[nextIndex]
+                index = nextIndex
+            } else {
+                print("Warning: --summary-file requires a file path. Ignoring option.")
             }
         default:
             inputs.append(argument)
@@ -145,5 +154,15 @@ if let path = options.visualizationPath {
         print("Visualization exported to \(url.path)")
     } catch {
         print("Failed to export visualization: \(error)")
+    }
+}
+
+if let path = options.summaryPath {
+    let url = URL(fileURLWithPath: path)
+    do {
+        try agent.exportSummary(to: url, limit: options.historyCount ?? 5)
+        print("Summary exported to \(url.path)")
+    } catch {
+        print("Failed to export summary: \(error)")
     }
 }

--- a/swift-ai-computer/Tests/swift-ai-computerTests/swift_ai_computerTests.swift
+++ b/swift-ai-computer/Tests/swift-ai-computerTests/swift_ai_computerTests.swift
@@ -42,4 +42,22 @@ final class swift_ai_computerTests: XCTestCase {
         // Check for table cell content instead of input format
         XCTAssertTrue(content.contains("<td>A</td>"))
     }
+
+    func testSummaryExport() throws {
+        let agent = AISupercomputer(seed: 42)
+        agent.respond(to: "A")
+        agent.respond(to: "?")
+
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("summary.txt")
+        try? FileManager.default.removeItem(at: tempURL)
+
+        try agent.exportSummary(to: tempURL, limit: 2)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempURL.path))
+        let content = try String(contentsOf: tempURL)
+        XCTAssertTrue(content.contains("Emotional state —"))
+        XCTAssertTrue(content.contains("Recent experiences:"))
+        XCTAssertTrue(content.contains("Input: A"))
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Provide a way to persist the same textual summary printed by `--summary` into a plain-text file for sharing or automation.
- Make summary output available programmatically so other tools or CI pipelines can consume the agent's report.

### Description
- Added `exportSummary(to:limit:)` to `AISupercomputer` to write the `summaryReport(limit:)` output to disk as a UTF-8 text file.
- Added a new CLI flag `--summary-file <path>` with a `summaryPath` field in `CLIOptions` and wired the runtime to call `exportSummary` after processing inputs.
- Documented the new `--summary-file` option in `README.md` and included a unit test `testSummaryExport` in the test suite to validate summary export semantics.

### Testing
- Ran `swift test` in this environment and it failed due to a toolchain mismatch because the package requires Swift tools `6.2.0` while the installed version is `6.1.3` so tests could not be executed here.
- Added `testSummaryExport` which creates a summary file and asserts presence of expected markers, and it should pass when run under a compatible Swift toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb9f0320883279e9db4f149230212)