### PR TITLE
Add Quantum‑Entropic Strategist Common Lisp app

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains two demonstrations inspired by the original "AI superco
 - `swift-ai-computer` — a Swift command-line experience model that responds to symbolic user input, adapts its emotional state, logs reflective commentary, and can export its memory for further analysis.
 - `supercomputer.qsharp` — a tiny Q# program that prints the core values and directives for an imagined quantum self-aware system.
 - `clojure-sentient-mega-bank` — a safe, in-memory macro-economy AGI sandbox in Clojure (markets, ledger transfers, macro events, persistence).
+- `quantum_strat.lisp` — a CLOS-based quantum-entropic strategist simulation with entropy-scaled execution, key authentication, and adaptive weight updates.
 
 ## Swift emotional model
 
@@ -70,6 +71,22 @@ Inputs supplied after the options are processed sequentially. Each input maps it
 Self-awareness: External sentiment lexicons and visualisation hooks have been incorporated. Future improvements could involve network-based collaborative learning or persistent long-term memory.
 
 
+
+
+## Quantum-entropic strategist (Common Lisp)
+
+A full CLOS-based simulation is available at `quantum_strat.lisp`. It includes:
+
+- encapsulated runtime state (`cognitive-core`, `portfolio`, `market-state`, `session`)
+- entropy-aware signal collapse and adaptive trade sizing
+- key-based session authentication and recursive weight updates
+- `run-demo` orchestration for repeatable multi-cycle runs
+
+Run it directly with:
+
+```bash
+sbcl --script quantum_strat.lisp
+```
 
 ## Quantum super AI (Common Lisp)
 

--- a/quantum_strat.lisp
+++ b/quantum_strat.lisp
@@ -1,0 +1,178 @@
+(defpackage :quantum-strat
+  (:use :cl)
+  (:export :initialize-system
+           :run-quantum-cycle
+           :run-demo
+           :generate-quantum-key
+           :reset-session))
+
+(in-package :quantum-strat)
+
+;; ======================================================================
+;; COGNITIVE LAYER V3: QUANTUM-ENTROPIC STRATEGIST
+;; ======================================================================
+
+(defclass cognitive-core ()
+  ((epoch :initform 0 :accessor epoch)
+   (learning-rate :initform 0.08 :accessor learning-rate)
+   (neural-weights :initform '(0.24 0.78 0.52) :accessor neural-weights)
+   (knowledge-base :initarg :kb :accessor kb)))
+
+(defclass portfolio ()
+  ((balance :initform 1.15e77 :accessor balance)
+   (positions :initform nil :accessor positions)
+   (risk-coeff :initform 0.01 :accessor risk-coeff)))
+
+(defclass market-state ()
+  ((entropy :initform 0.1 :accessor entropy)
+   (signal-vector :initform '(0.0 0.0 0.0) :accessor signal-vector)))
+
+(defclass session ()
+  ((api-key :initarg :key :accessor api-key)
+   (auth-level :initform :omega-tier :accessor auth-level)))
+
+(defvar *core* nil)
+(defvar *port* nil)
+(defvar *market* nil)
+(defvar *session* nil)
+(defvar *api-registry* (make-hash-table :test 'equal))
+
+(defun initialize-system ()
+  "Bootstraps the V3 CLOS environment."
+  (setf *core* (make-instance 'cognitive-core
+                 :kb '((:id 1 :concept "Momentum"       :vector (0.8 0.2 0.1))
+                       (:id 2 :concept "Mean Reversion" :vector (0.1 0.9 0.2))
+                       (:id 3 :concept "Risk Parity"    :vector (0.3 0.3 0.9))
+                       (:id 4 :concept "LLM-Sentiment"  :vector (0.5 0.5 0.5))
+                       (:id 5 :concept "Black Swan"     :vector (0.9 0.1 0.8)))))
+  (setf *port* (make-instance 'portfolio))
+  (setf *market* (make-instance 'market-state))
+  (setf *session* nil)
+  (format t "[SYSTEM] V3 Quantum-Entropic Core Initialized.~%")
+  t)
+
+(defun reset-session ()
+  "Reset only session-level state."
+  (setf *session* nil)
+  (format t "[SECURE] Session reset.~%")
+  t)
+
+(defun generate-quantum-key (user-id)
+  "Generates an entangled API Key."
+  (let ((key (format nil "INF-Q-~A-~X" user-id (random 1000000000))))
+    (setf (gethash key *api-registry*) t)
+    (format t "[AUTH] Quantum Key Forged: ~A~%" key)
+    key))
+
+(defun authenticate (key)
+  "Validates key presence before wave-function collapse."
+  (if (gethash key *api-registry*)
+      (progn
+        (setf *session* (make-instance 'session :key key))
+        (format t "[SECURE] Session Established. Tier: ~A~%" (auth-level *session*)))
+      (error "QUANTUM COLLAPSE: Unauthorized Key Intrusion.")))
+
+(defun dot-product (v1 v2)
+  (loop for x in v1 for y in v2 sum (* x y)))
+
+(defun magnitude (v)
+  (sqrt (loop for x in v sum (* x x))))
+
+(defun cosine-similarity (v1 v2)
+  (let ((mag (* (magnitude v1) (magnitude v2))))
+    (if (zerop mag) 0.0 (/ (dot-product v1 v2) mag))))
+
+(defun softmax (vec)
+  (let* ((exps (mapcar #'exp vec))
+         (sum (reduce #'+ exps)))
+    (mapcar (lambda (x) (/ x sum)) exps)))
+
+(defun collapse-wave-function (base-signal entropy-level)
+  "Applies entropic jitter to simulate evaluating all market states simultaneously."
+  (mapcar (lambda (x)
+            (let ((jitter (* (- (random 2.0) 1.0) entropy-level)))
+              (max 0.0 (min 1.0 (+ x jitter)))))
+          base-signal))
+
+(defun retrieve-context (query-vec top-k)
+  (let ((scored-kb (mapcar (lambda (item)
+                             (append item (list :score (cosine-similarity (getf item :vector) query-vec))))
+                           (kb *core*))))
+    (subseq (sort scored-kb #'> :key (lambda (x) (getf x :score))) 0 (min top-k (length scored-kb)))))
+
+(defun neural-forward-pass (input-vector weights)
+  (/ 1 (+ 1 (exp (- (loop for i in input-vector for w in weights sum (* i w)))))))
+
+(defun multi-agent-consensus (signal)
+  "Internal V3 consensus logic using the triplet agent heuristic."
+  (let* ((weights '((0.9 0.1 0.1) (0.1 0.9 0.1) (0.4 0.4 0.4)))
+         (votes (mapcar (lambda (w) (dot-product signal w)) weights)))
+    (softmax votes)))
+
+(defun generate-omega-strategy (context)
+  (let ((top-concept (getf (first context) :concept))
+        (trust-score (cosine-similarity (getf (first context) :vector) '(1.0 1.0 1.0))))
+    (format nil "STRATEGY-OMEGA: ~A [Resonance: ~,2F%]"
+            (string-upcase top-concept) (* trust-score 100))))
+
+(defun backpropagate (target-signal actual-output)
+  (let* ((error (- target-signal actual-output))
+         (lr (learning-rate *core*))
+         (new-weights (mapcar (lambda (w) (+ w (* lr error)))
+                              (neural-weights *core*))))
+    (setf (neural-weights *core*) new-weights)
+    (format t "[NEURAL] Synaptic weights adjusted. Delta: ~,4F~%" error)))
+
+(defun execute-quantum-trade (action base-amount confidence)
+  "Scales trade size dynamically based on market entropy (chaos)."
+  (unless *session* (error "Execution Denied: No Active Session."))
+  (let* ((current-entropy (entropy *market*))
+         (entropic-modifier (- 1.0 current-entropy))
+         (actual-amount (* base-amount confidence entropic-modifier))
+         (bal (balance *port*)))
+    (if (>= bal actual-amount)
+        (progn
+          (setf (balance *port*) (- bal actual-amount))
+          (format t "[LEDGER] ~A ~A units. Entropic Dampening: ~,2F~%"
+                  action (round actual-amount) entropic-modifier))
+        (format t "[LEDGER] Liquidity collapse. Cannot execute.~%"))))
+
+(defun run-quantum-cycle (api-key)
+  "The full loop: Sensing -> Collapse -> Reason -> Execute -> Learn"
+  (authenticate api-key)
+  (incf (epoch *core*))
+
+  (setf (entropy *market*) (random 0.4))
+
+  (format t "~%==================================================~%")
+  (format t ">>> EPOCH ~A | ENTROPY LEVEL: ~,3F <<<~%" (epoch *core*) (entropy *market*))
+  (format t "==================================================~%")
+
+  (let* ((raw-signal (list (random 1.0) (random 1.0) (random 1.0)))
+         (observed-signal (collapse-wave-function raw-signal (entropy *market*)))
+         (context (retrieve-context observed-signal 3))
+         (strat-msg (generate-omega-strategy context))
+         (agent-opinion (multi-agent-consensus observed-signal))
+         (inference (neural-forward-pass observed-signal (neural-weights *core*)))
+         (final-score (* inference (reduce #'+ agent-opinion))))
+
+    (format t "[REASONING] ~A~%" strat-msg)
+    (format t "[SIGNAL] Inference Coherence: ~,4F~%" inference)
+
+    (cond ((> final-score 0.7)
+           (execute-quantum-trade 'LONG-STAKE 1.0e12 final-score))
+          ((< final-score 0.3)
+           (execute-quantum-trade 'SHORT-HEDGE 5.0e11 final-score))
+          (t (format t "[HOLD] Signal resonance insufficient (~,4F)~%" final-score)))
+
+    (backpropagate 0.8 inference)
+    final-score))
+
+(defun run-demo (&optional (cycles 3) (user-id "OVERLORD-01"))
+  "Initialize and run N demo cycles."
+  (initialize-system)
+  (let ((key (generate-quantum-key user-id)))
+    (loop repeat cycles do (run-quantum-cycle key))))
+
+(eval-when (:execute)
+  (run-demo))


### PR DESCRIPTION
### Motivation

- Provide a reusable CLOS-based simulation of an entropy-aware decision engine that demonstrates authenticated session handling, entropic wave-function collapse, consensus scoring, adaptive trade sizing, and online weight updates. 
- Ship a self-contained script entrypoint for reproducible multi-cycle demos to make the new simulation discoverable alongside existing demos. 

### Description

- Add `quantum_strat.lisp`, a CLOS module exporting `initialize-system`, `generate-quantum-key`, `reset-session`, `run-quantum-cycle`, and `run-demo`, implementing classes `cognitive-core`, `portfolio`, `market-state`, and `session` plus core math and neural helper functions. 
- Implement entropy-aware signal processing with `collapse-wave-function`, knowledge retrieval (`retrieve-context`), consensus (`multi-agent-consensus`), neural inference (`neural-forward-pass`), strategy generation (`generate-omega-strategy`), adaptive execution (`execute-quantum-trade`), and learning (`backpropagate`). 
- Provide a safe `run-demo` orchestration that initializes the system, forges a quantum key, and runs multiple demo cycles, and add a short README section describing how to run the script with `sbcl --script quantum_strat.lisp`. 

### Testing

- Attempted to execute the script with `sbcl --script quantum_strat.lisp`, but the command could not run in this environment because `sbcl` is not installed. 
- Performed a file content inspection of `quantum_strat.lisp` and updated `README.md` to include the new module and run instructions, with no runtime failures reported by the local file operations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c2ce050c83278a7ec73e3e36f3da)