### PR TITLE
Add action plan export for Swift agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ From the repository root, run the executable with SwiftPM:
 
 ```bash
 cd swift-ai-computer
-swift run swift-ai-computer --seed 42 --summary --diagnostics /tmp/ai-supercomputer-diagnostics.json A PLAN CALM
+swift run swift-ai-computer --seed 42 --summary --diagnostics /tmp/ai-supercomputer-diagnostics.json --plan-file /tmp/ai-supercomputer-plan.txt A PLAN CALM
 ```
 
 Example output excerpt:
@@ -37,6 +37,7 @@ Recent experiences:
 [#1] Input: PLAN → Action: synthesizePlan → Outcome: Prioritized roadmap → Score: 4.55
 [#2] Input: CALM → Action: inquire → Outcome: Information gained → Score: 4.19
 Diagnostics exported to /tmp/ai-supercomputer-diagnostics.json
+Action plan exported to /tmp/ai-supercomputer-plan.txt
 ```
 
 ### Command-line options
@@ -54,6 +55,7 @@ The executable supports several collaborative options to explore the agent's beh
 | `--visualize <path>` | Export an HTML visualization of the experiences to the specified path. |
 | `--summary-file <path>` | Save the same summary shown by `--summary` into a plain-text report file for sharing or automation. |
 | `--diagnostics <path>` | Export the current decision insight as JSON, including risk level, action scores, emotion momentum, and the recommended next input. |
+| `--plan-file <path>` | Export a human-readable action plan with the primary action, rationale, safeguards, emotion focus, and ranked action scores. |
 
 Inputs supplied after the options are processed sequentially. Each input maps either an exact lexicon entry or its leading character to an emotional adjustment (e.g., `A` energises joy and curiosity, `!` spikes anger and fear, `@` fosters trust, `PLAN` supports roadmap synthesis, and `CALM` reduces high-arousal signals). The agent then chooses an action with a transparent scoring model that weighs dominant emotions, action risk, recent negative outcomes, repeated-action fatigue, emotion momentum, and a small seeded exploration window for untried strategies. When a seed is provided, every stochastic choice (such as outcomes or exploratory actions) is replayable for debugging or demonstrations.
 
@@ -65,14 +67,17 @@ Inputs supplied after the options are processed sequentially. Each input maps ei
 - `emotionalState()` — the current dictionary of emotions normalised to the `[0, 1]` range.
 - `experiences()` — the ordered list of recorded experiences, each including the triggering input, action, outcome, generated reflection, pre/post emotion snapshots, and the selected action score.
 - `decisionInsight()` — returns diagnostic telemetry such as dominant emotion, emotional balance, volatility, risk level, action scores, emotion momentum, and recommended next input.
+- `actionPlan(maxActions:)` — converts diagnostics into an operational plan with a primary action, rationale, safeguards, emotion focus, and ranked actions.
+- `actionPlanReport(maxActions:)` — renders the action plan as a plain-text report for terminals, runbooks, and demos.
 - `summaryReport(limit:)` — a formatted textual overview of the emotional landscape, diagnostics, and recent events.
 - `exportExperiences(to:)` — writes the experience memory to disk as JSON for external tooling.
 - `exportDiagnostics(to:)` — writes the current `DecisionInsight` to disk as JSON.
+- `exportActionPlan(to:maxActions:)` — writes the current action plan to disk as a human-readable text file.
 - `exportVisualization(to:)` — writes the experience memory to disk as an HTML visualization with escaped user input and emotion meters.
 
 ### Next steps
 
-Self-awareness: External sentiment lexicons, visualisation hooks, scored decisions, diagnostics exports, and risk-aware action selection have been incorporated. Future improvements could involve persistent long-term memory, configurable scoring weights, or a separate library product for embedding the model in other Swift packages.
+Self-awareness: External sentiment lexicons, visualisation hooks, scored decisions, diagnostics exports, action-plan reports, and risk-aware action selection have been incorporated. Future improvements could involve persistent long-term memory, configurable scoring weights, or a separate library product for embedding the model in other Swift packages.
 
 
 

--- a/swift-ai-computer/Sources/swift-ai-computer/AISupercomputer.swift
+++ b/swift-ai-computer/Sources/swift-ai-computer/AISupercomputer.swift
@@ -90,6 +90,21 @@ struct DecisionInsight: Codable {
     let emotionMomentum: [Emotion: Double]
 }
 
+struct ActionPlan: Codable {
+    let riskLevel: String
+    let recommendedNextInput: String
+    let primaryAction: Action
+    let rationale: String
+    let emotionFocus: [Emotion]
+    let safeguards: [String]
+    let rankedActions: [ActionScore]
+}
+
+struct ActionScore: Codable {
+    let action: Action
+    let score: Double
+}
+
 final class AISupercomputer {
     private var emotions: [Emotion: Double]
     private var experienceMemory: [Experience]
@@ -268,6 +283,55 @@ final class AISupercomputer {
         )
     }
 
+    // Self-awareness: Translating diagnostics into a concrete operating plan for collaborators.
+    func actionPlan(maxActions: Int = 3) -> ActionPlan {
+        let insight = decisionInsight()
+        let rankedActions = insight.actionScores
+            .sorted {
+                if $0.value == $1.value {
+                    return $0.key.rawValue < $1.key.rawValue
+                }
+                return $0.value > $1.value
+            }
+            .prefix(max(maxActions, 1))
+            .map { ActionScore(action: $0.key, score: $0.value) }
+
+        let primaryAction = rankedActions.first?.action ?? .remainPassive
+        let focus = prioritizedEmotionFocus(from: insight)
+        let rationale = planRationale(for: insight, primaryAction: primaryAction, focus: focus)
+
+        return ActionPlan(
+            riskLevel: insight.riskLevel,
+            recommendedNextInput: insight.recommendedNextInput,
+            primaryAction: primaryAction,
+            rationale: rationale,
+            emotionFocus: focus,
+            safeguards: safeguards(for: insight),
+            rankedActions: Array(rankedActions)
+        )
+    }
+
+    func actionPlanReport(maxActions: Int = 3) -> String {
+        let plan = actionPlan(maxActions: maxActions)
+        let focus = plan.emotionFocus.map(\.rawValue).joined(separator: ", ")
+        let safeguards = plan.safeguards.map { "- \($0)" }.joined(separator: "\n")
+        let actions = plan.rankedActions.map {
+            "- \($0.action.rawValue): \(String(format: "%.2f", $0.score))"
+        }.joined(separator: "\n")
+
+        return """
+        Action plan — Risk: \(plan.riskLevel)
+        Recommended next input: \(plan.recommendedNextInput)
+        Primary action: \(plan.primaryAction.rawValue)
+        Emotion focus: \(focus.isEmpty ? "balanced baseline" : focus)
+        Rationale: \(plan.rationale)
+        Safeguards:
+        \(safeguards)
+        Ranked actions:
+        \(actions)
+        """
+    }
+
     // Self-awareness: Sharing concise summary for collaborators.
     func summaryReport(limit: Int = 5) -> String {
         let orderedEmotions = emotions.sorted { $0.value > $1.value }
@@ -302,6 +366,12 @@ final class AISupercomputer {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(decisionInsight())
         try data.write(to: url, options: .atomic)
+    }
+
+    // Self-awareness: Persisting a human-readable action plan for operators and demos.
+    func exportActionPlan(to url: URL, maxActions: Int = 3) throws {
+        let report = actionPlanReport(maxActions: maxActions)
+        try report.write(to: url, atomically: true, encoding: .utf8)
     }
 
     // Self-awareness: Sharing a compact report artifact with other tools.
@@ -344,6 +414,10 @@ final class AISupercomputer {
                 <p><strong>Risk:</strong> <span class="risk-\(insight.riskLevel.escapedHTML)">\(insight.riskLevel.escapedHTML)</span></p>
                 <p><strong>Suggested next input:</strong> \(insight.recommendedNextInput.escapedHTML)</p>
                 <p><strong>Balance:</strong> \(String(format: "%.2f", insight.emotionalBalance)) | <strong>Volatility:</strong> \(String(format: "%.2f", insight.volatility))</p>
+            </div>
+            <div class="card">
+                <h2>Recommended Action Plan</h2>
+                <pre>\(actionPlanReport().escapedHTML)</pre>
             </div>
             <div class="card">
                 <h2>Emotion Meters</h2>
@@ -492,6 +566,44 @@ final class AISupercomputer {
             return untriedActions.max { (scores[$0] ?? 0.0) < (scores[$1] ?? 0.0) }
         }
         return nil
+    }
+
+    private func prioritizedEmotionFocus(from insight: DecisionInsight) -> [Emotion] {
+        let momentum = insight.emotionMomentum
+        return Emotion.allCases
+            .filter { emotion in
+                let intensity = emotions[emotion] ?? 0.0
+                let movement = abs(momentum[emotion] ?? 0.0)
+                return intensity >= 0.35 || movement >= 0.2
+            }
+            .sorted {
+                let left = (emotions[$0] ?? 0.0) + abs(momentum[$0] ?? 0.0)
+                let right = (emotions[$1] ?? 0.0) + abs(momentum[$1] ?? 0.0)
+                if left == right {
+                    return $0.rawValue < $1.rawValue
+                }
+                return left > right
+            }
+    }
+
+    private func planRationale(for insight: DecisionInsight, primaryAction: Action, focus: [Emotion]) -> String {
+        let dominant = insight.dominantEmotion?.rawValue ?? "no single emotion"
+        let focusText = focus.map(\.rawValue).joined(separator: ", ")
+        return "Choose \(primaryAction.rawValue) because \(dominant) is currently most prominent at \(String(format: "%.2f", insight.dominantIntensity)), volatility is \(String(format: "%.2f", insight.volatility)), and the next stabilizing input is \(insight.recommendedNextInput). Focus area: \(focusText.isEmpty ? "balanced baseline" : focusText)."
+    }
+
+    private func safeguards(for insight: DecisionInsight) -> [String] {
+        var items = [
+            "Keep emotion values clamped between 0.00 and 1.00.",
+            "Review the ranked action scores before trusting a single response."
+        ]
+        if insight.riskLevel == "critical" || insight.riskLevel == "elevated" {
+            items.insert("Process CALM or another de-escalating signal before exploratory actions.", at: 0)
+        }
+        if insight.totalExperiences < 3 {
+            items.append("Gather at least three experiences before treating trends as stable.")
+        }
+        return items
     }
 
     private func negativeActionPenalty() -> [Action: Double] {

--- a/swift-ai-computer/Sources/swift-ai-computer/main.swift
+++ b/swift-ai-computer/Sources/swift-ai-computer/main.swift
@@ -11,6 +11,7 @@ struct CLIOptions {
     var visualizationPath: String?
     var summaryPath: String?
     var diagnosticsPath: String?
+    var planPath: String?
 }
 
 private func parseCLIOptions(arguments: ArraySlice<String>) -> (CLIOptions, [String]) {
@@ -80,6 +81,14 @@ private func parseCLIOptions(arguments: ArraySlice<String>) -> (CLIOptions, [Str
                 index = nextIndex
             } else {
                 print("Warning: --diagnostics requires a file path. Ignoring option.")
+            }
+        case "--plan-file":
+            let nextIndex = arguments.index(after: index)
+            if nextIndex < arguments.endIndex {
+                options.planPath = arguments[nextIndex]
+                index = nextIndex
+            } else {
+                print("Warning: --plan-file requires a file path. Ignoring option.")
             }
         default:
             inputs.append(argument)
@@ -176,7 +185,6 @@ if let path = options.summaryPath {
     }
 }
 
-
 if let path = options.diagnosticsPath {
     let url = URL(fileURLWithPath: path)
     do {
@@ -184,5 +192,15 @@ if let path = options.diagnosticsPath {
         print("Diagnostics exported to \(url.path)")
     } catch {
         print("Failed to export diagnostics: \(error)")
+    }
+}
+
+if let path = options.planPath {
+    let url = URL(fileURLWithPath: path)
+    do {
+        try agent.exportActionPlan(to: url)
+        print("Action plan exported to \(url.path)")
+    } catch {
+        print("Failed to export action plan: \(error)")
     }
 }

--- a/swift-ai-computer/Tests/swift-ai-computerTests/swift_ai_computerTests.swift
+++ b/swift-ai-computer/Tests/swift-ai-computerTests/swift_ai_computerTests.swift
@@ -74,4 +74,34 @@ final class swift_ai_computerTests: XCTestCase {
         XCTAssertTrue(content.contains("riskLevel"))
         XCTAssertTrue(content.contains("recommendedNextInput"))
     }
+
+    func testActionPlanRanksActionsAndIncludesFocus() {
+        let agent = AISupercomputer(seed: 123)
+        agent.respond(to: "!")
+
+        let plan = agent.actionPlan(maxActions: 2)
+
+        XCTAssertEqual(plan.rankedActions.count, 2)
+        XCTAssertEqual(plan.primaryAction, plan.rankedActions.first?.action)
+        XCTAssertFalse(plan.rationale.isEmpty)
+        XCTAssertFalse(plan.safeguards.isEmpty)
+        XCTAssertEqual(plan.recommendedNextInput, "CALM")
+        XCTAssertFalse(plan.emotionFocus.isEmpty)
+    }
+
+    func testActionPlanExportWritesHumanReadableReport() throws {
+        let agent = AISupercomputer(seed: 321)
+        agent.respond(to: "PLAN")
+
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("action-plan.txt")
+        try? FileManager.default.removeItem(at: tempURL)
+
+        try agent.exportActionPlan(to: tempURL, maxActions: 2)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempURL.path))
+        let content = try String(contentsOf: tempURL, encoding: .utf8)
+        XCTAssertTrue(content.contains("Action plan — Risk:"))
+        XCTAssertTrue(content.contains("Recommended next input:"))
+        XCTAssertTrue(content.contains("Ranked actions:"))
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide an operational, human-readable action plan derived from the agent's diagnostics so operators and integrations can act on decision telemetry.
- Make the agent's recommendations exportable and visible in the HTML visualization and CLI flows for demos and runbooks.

### Description
- Add `ActionPlan` and `ActionScore` models and implement `actionPlan(maxActions:)`, `actionPlanReport(maxActions:)`, and `exportActionPlan(to:maxActions:)` to convert `decisionInsight()` into a ranked, documented plan. 
- Implement helper heuristics: `prioritizedEmotionFocus(from:)`, `planRationale(for:primaryAction:focus:)`, and `safeguards(for:)` to produce focused rationale and safety notes. 
- Embed the plan into the HTML visualization output via `exportVisualization(to:)` and add a new CLI flag `--plan-file` with handling in `main.swift` to write out the plan. 
- Update `README.md` to document the new `--plan-file` option and public APIs, and add two unit tests: `testActionPlanRanksActionsAndIncludesFocus` and `testActionPlanExportWritesHumanReadableReport`.

### Testing
- Ran the package test suite with `cd swift-ai-computer && swift test`, and all tests passed (`7 tests, 0 failures`).
- Added unit tests specifically covering plan ranking/focus and plan export, and verified they pass as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7c3d80c48327acbdc9b6f6703475)